### PR TITLE
Condor Bringup

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2843,4 +2843,9 @@
 
     <!-- Whether notify fingerprint client of successful cancelled authentication -->
     <bool name="config_notifyClientOnFingerprintCancelSuccess">false</bool>
+
+    <!-- Older rotation sensors are not setting event.timestamp correctly. Setting to 
+         true will use SystemClock.elapsedRealtimeNanos() to set timestamp. --> 
+    <bool name="config_useSystemClockforRotationSensor">false</bool> 
+
 </resources>

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -2848,4 +2848,7 @@
   <java-symbol type="bool" name="use_lock_pattern_drawable" />
   <java-symbol type="drawable" name="lockscreen_notselected" />
   <java-symbol type="drawable" name="lockscreen_selected" />
+
+  <!-- Bool to fix legacy sensors -->
+  <java-symbol type="bool" name="config_useSystemClockforRotationSensor" /> 
 </resources>

--- a/services/core/java/com/android/server/policy/WindowOrientationListener.java
+++ b/services/core/java/com/android/server/policy/WindowOrientationListener.java
@@ -56,6 +56,7 @@ public abstract class WindowOrientationListener {
     private boolean mEnabled;
     private int mRate;
     private String mSensorType;
+    private boolean mUseSystemClockforRotationSensor; 
     private Sensor mSensor;
     private OrientationJudge mOrientationJudge;
     private int mCurrentRotation = -1;
@@ -89,6 +90,9 @@ public abstract class WindowOrientationListener {
         mSensorManager = (SensorManager)context.getSystemService(Context.SENSOR_SERVICE);
         mRate = rate;
         mSensor = mSensorManager.getDefaultSensor(Sensor.TYPE_DEVICE_ORIENTATION);
+
+        mUseSystemClockforRotationSensor = context.getResources().getBoolean(
+                com.android.internal.R.bool.config_useSystemClockforRotationSensor);
 
         if (mSensor != null) {
             mOrientationJudge = new OrientationSensorJudge();
@@ -597,7 +601,8 @@ public abstract class WindowOrientationListener {
                 // Reset the orientation listener state if the samples are too far apart in time
                 // or when we see values of (0, 0, 0) which indicates that we polled the
                 // accelerometer too soon after turning it on and we don't have any data yet.
-                final long now = event.timestamp;
+                final long now = mUseSystemClockforRotationSensor
+                        ? SystemClock.elapsedRealtimeNanos() : event.timestamp;
                 final long then = mLastFilteredTimestampNanos;
                 final float timeDeltaMS = (now - then) * 0.000001f;
                 final boolean skipSample;


### PR DESCRIPTION
Older devices may have an issue with rotation freezes up and
requires a reboot to fix. In deep sleep the sensor's timestamp
is far off, depending how long it's in sleep, causing rotation
not to work. onSensorChanged if true it will use
SystemClock.elapsedRealtimeNanos() instead of event.timestamp.
Possibly an update to the custom sensor libs.

Signed-off-by: DarkKnight6499 <yazad.madan@gmail.com>